### PR TITLE
Delete wire save file on chip deletion.

### DIFF
--- a/Assets/Scripts/Save System/ChipDelete.cs
+++ b/Assets/Scripts/Save System/ChipDelete.cs
@@ -25,9 +25,11 @@ public class ChipDelete : MonoBehaviour
     public void ConfirmDelete()
     {
         string deletePath = SaveSystem.GetPathToSaveFile(name);
+	string wireDeletePath = SaveSystem.GetPathToWireSaveFile(name);
         Debug.Log(deletePath);
         if (File.Exists(deletePath)) {
             File.Delete(deletePath);
+	    File.Delete(wireDeletePath);
             _manager.RefreshAll();
         }
 


### PR DESCRIPTION
Fixes #15, didn't test but should work.
